### PR TITLE
Replace Akka with Akka-http when it refers to the project name #429

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,44 +8,41 @@ In case of questions about the contribution process or for discussion of specifi
 
 Depending on which version (or sometimes module) you want to work on, you should target a specific branch as explained below:
 
-* `master` – active development branch of Akka 2.4.x
-* `release-2.3` – maintenance branch of Akka 2.3.x
-* `artery-dev` – work on the upcoming remoting implementation, codenamed "artery"
-* similarly `release-2.#` branches contain legacy versions of Akka
+* `master` – active development branch of akka-http 3.0-SNAPSHOT
 
 ## Tags
 
-Akka uses tags to categorise issues into groups or mark their phase in development.
+Akka-http uses tags to categorise issues into groups or mark their phase in development.
 
 Most notably many tags start `t:` prefix (as in `topic:`), which categorises issues in terms of which module they relate to. Examples are:
 
-- [t:core](https://github.com/akka/akka/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3At%3Acore)
-- [t:stream](https://github.com/akka/akka/issues?q=is%3Aissue+is%3Aopen+label%3At%3Astream)
-- see [all tags here](https://github.com/akka/akka/labels)
+- [t:http:core](https://github.com/akka/akka-http/issues?q=is%3Aopen+is%3Aissue+label%3At%3Ahttp%3Acore)
+- [t:server:dsl](https://github.com/akka/akka-http/issues?q=is%3Aopen+is%3Aissue+label%3At%3Ahttp%3Aserver%3Adsl)
+- see [all tags here](https://github.com/akka/akka-http/labels)
 
 In general *all issues are open for anyone working on them*, however if you're new to the project and looking for an issue
 that will be accepted and likely is a nice one to get started you should check out the following tags:
 
-- [community](https://github.com/akka/akka/labels/community) - which identifies issues that the core team will likely not have time to work on, or the issue is a nice entry level ticket. If you're not sure how to solve a ticket but would like to work on it feel free to ask in the issue about clarification or tips.
-- [nice-to-have (low-priority)](https://github.com/akka/akka/labels/nice-to-have%20%28low-prio%29) - are tasks which make sense, however are not very high priority (in face of other very high priority issues). If you see something interesting in this list, a contribution would be really wonderful!
+- [community](https://github.com/akka/akka-http/labels/community) - which identifies issues that the core team will likely not have time to work on, or the issue is a nice entry level ticket. If you're not sure how to solve a ticket but would like to work on it feel free to ask in the issue about clarification or tips.
+- [nice-to-have (low-priority)](https://github.com/akka/akka-http/labels/nice-to-have%20%28low-prio%29) - are tasks which make sense, however are not very high priority (in face of other very high priority issues). If you see something interesting in this list, a contribution would be really wonderful!
 
 Another group of tickets are those which start from a number. They're used to signal in what phase of development an issue is:
 
-- [0 - new](https://github.com/akka/akka/labels/0%20-%20new) - is assigned when a ticket is unclear on it's purpose or if it is valid or not. Sometimes the additional tag `discuss` is used to mark such tickets, if they propose large scale changed and need more discussion before moving into triaged (or being closed as invalid)
-- [1 - triaged](https://github.com/akka/akka/labels/1%20-%20triaged) - roughly speaking means "this ticket makes sense". Triaged tickets are safe to pick up for contributing in terms of likeliness of a patch for it being accepted. It is not recommended to start working on a ticket that is not triaged.
-- [2 - pick next](https://github.com/akka/akka/labels/2%20-%20pick%20next) - used to mark issues which are next up in the queue to be worked on. Sometimes it's also used to mark which PRs are expected to be reviewed/merged for the next release. The tag is non-binding, and mostly used as organisational helper.
-- [3 - in progress](https://github.com/akka/akka/labels/3%20-%20in%20progress) - means someone is working on this ticket. If you see a ticket that has the tag, however seems inactive, it could have been an omission with removing the tag, feel free to ping the ticket then if it's still being worked on.
+- [0 - new](https://github.com/akka/akka-http/labels/0%20-%20new) - is assigned when a ticket is unclear on it's purpose or if it is valid or not. Sometimes the additional tag `discuss` is used to mark such tickets, if they propose large scale changed and need more discussion before moving into triaged (or being closed as invalid)
+- [1 - triaged](https://github.com/akka/akka-http/labels/1%20-%20triaged) - roughly speaking means "this ticket makes sense". Triaged tickets are safe to pick up for contributing in terms of likeliness of a patch for it being accepted. It is not recommended to start working on a ticket that is not triaged.
+- [2 - pick next](https://github.com/akka/akka-http/labels/2%20-%20pick%20next) - used to mark issues which are next up in the queue to be worked on. Sometimes it's also used to mark which PRs are expected to be reviewed/merged for the next release. The tag is non-binding, and mostly used as organisational helper.
+- [3 - in progress](https://github.com/akka/akka-http/labels/3%20-%20in%20progress) - means someone is working on this ticket. If you see a ticket that has the tag, however seems inactive, it could have been an omission with removing the tag, feel free to ping the ticket then if it's still being worked on.
 
 The last group of special tags indicate specific states a ticket is in:
 
-- [bug](https://github.com/akka/akka/labels/failed) - bugs take priority in being fixed above features. The core team dedicates a number of days to working on bugs each sprint. Bugs which have reproducers are also great for community contributions as they're well isolated. Sometimes we're not as lucky to have reproducers though, then a bugfix should also include a test reproducing the original error along with the fix.
-- [failed](https://github.com/akka/akka/labels/failed) - tickets indicate a Jenkins failure (for example from a nightly build). These tickets usually start with the `FAILED: ...` message, and include a stacktrace + link to the Jenkins failure. The tickets are collected and worked on with priority to keep the build stable and healthy. Often times it may be simple timeout issues (Jenkins boxes are slow), though sometimes real bugs are discovered this way.
+- [bug](https://github.com/akka/akka-http/labels/bug) - bugs take priority in being fixed above features. The core team dedicates a number of days to working on bugs each sprint. Bugs which have reproducers are also great for community contributions as they're well isolated. Sometimes we're not as lucky to have reproducers though, then a bugfix should also include a test reproducing the original error along with the fix.
+- [failed](https://github.com/akka/akka-http/labels/failed) - tickets indicate a Jenkins failure (for example from a nightly build). These tickets usually start with the `FAILED: ...` message, and include a stacktrace + link to the Jenkins failure. The tickets are collected and worked on with priority to keep the build stable and healthy. Often times it may be simple timeout issues (Jenkins boxes are slow), though sometimes real bugs are discovered this way.
 
 Pull Request validation states:
 
 - `validating => [tested | needs-attention]` - signify pull request validation status
 
-# Akka contributing guidelines
+# Akka-http contributing guidelines
 
 These guidelines apply to all Akka projects, by which we mean both the `akka/akka` repository,
 as well as any plugins or additional repos located under the Akka GitHub organisation, e.g. `akka/akka-http` and others.
@@ -58,9 +55,9 @@ We encourage changes that make it easier to achieve our goals in an efficient wa
 The below steps are how to get a patch into a main development branch (e.g. `master`). 
 The steps are exactly the same for everyone involved in the project (be it core team, or first time contributor).
 
-1. Make sure an issue exists in the [issue tracker](https://github.com/akka/akka/issues) for the work you want to contribute. 
-   - If there is no ticket for it, [create one](https://github.com/akka/akka/issues/new) first.
-1. [Fork the project](https://github.com/akka/akka#fork-destination-box) on GitHub. You'll need to create a feature-branch for your work on your fork, as this way you'll be able to submit a PullRequest against the mainline Akka.
+1. Make sure an issue exists in the [issue tracker](https://github.com/akka/akka-http/issues) for the work you want to contribute. 
+   - If there is no ticket for it, [create one](https://github.com/akka/akka-http/issues/new) first.
+1. [Fork the project](https://github.com/akka/akka-http#fork-destination-box) on GitHub. You'll need to create a feature-branch for your work on your fork, as this way you'll be able to submit a PullRequest against the mainline Akka-http.
 1. Create a branch on your fork and work on the feature. For example: `git checkout -b wip-custom-headers-akka-http`
    - Please make sure to follow the general quality guidelines (specified below) when developing your patch.
    - Please write additional tests covering your feature and adjust existing ones if needed before submitting your Pull Request. The `validatePullRequest` sbt task ([explained below](#validatePullRequest)) may come in handy to verify your changes are correct.
@@ -78,18 +75,18 @@ The steps are exactly the same for everyone involved in the project (be it core 
 
 The TL;DR; of the above very precise workflow version is:
 
-1. Fork Akka
+1. Fork akka-http
 2. Hack and test on your feature (on a branch)
 3. Submit a PR
 4. Sign the CLA if necessary
 4. Keep polishing it until received enough LGTM
 5. Profit!
 
-Note that the Akka sbt project is large, so `sbt` needs to be run with lots of heap (1-2 Gb). This can be specified using a command line argument `sbt -mem 2048` or in the environment variable `SBT_OPTS` but then as a regular JVM memory flag, for example `SBT_OPTS=-Xmx2G`, on some platforms you can also edit the global defaults for sbt in `/usr/local/etc/sbtopts`.
+Note that the akka-http sbt project is not as large as the Akka one, so `sbt` should be able to run with less heap than with the Akka project. In case you need to increase the heap, this can be specified using a command line argument `sbt -mem 2048` or in the environment variable `SBT_OPTS` but then as a regular JVM memory flag, for example `SBT_OPTS=-Xmx2G`, on some platforms you can also edit the global defaults for sbt in `/usr/local/etc/sbtopts`.
 
 ## The `validatePullRequest` task
 
-The Akka build includes a special task called `validatePullRequest` which investigates the changes made as well as dirty
+The Akka-http build includes a special task called `validatePullRequest` which investigates the changes made as well as dirty
 (uncommitted changes) in your local working directory and figures out which projects are impacted by those changes,
 then running tests only on those projects.
 
@@ -116,7 +113,7 @@ PR_TARGET_BRANCH=origin/example sbt validatePullRequest
 Binary compatibility rules and guarantees are described in depth in the [Binary Compatibility Rules
 ](http://doc.akka.io/docs/akka/snapshot/common/binary-compatibility-rules.html) section of the documentation.
 
-Akka uses MiMa (which is short for [Lightbend Migration Manager](https://github.com/typesafehub/migration-manager)) to
+Akka-http uses MiMa (which is short for [Lightbend Migration Manager](https://github.com/typesafehub/migration-manager)) to
 validate binary compatibility of incoming Pull Requests. If your PR fails due to binary compatibility issues, you may see 
 an error like this:
 
@@ -148,7 +145,7 @@ For a Pull Request to be considered at all it has to meet these requirements:
     1. All source files in the project must have a Lightbend copyright notice in the file header.
     1. The Notices file for the project includes the Lightbend copyright notice and no other files contain copyright notices.  See http://www.apache.org/legal/src-headers.html for instructions for managing this approach for copyrights.
 
-    Akka uses the first choice, having copyright notices in every file header.
+    Akka-http uses the first choice, having copyright notices in every file header.
 
 
 ### Additional guidelines
@@ -190,7 +187,7 @@ The rendered documentation will be available under `docs/target/paradox/site/ind
 
 ### JavaDoc
 
-Akka generates JavaDoc-style API documentation using the [genjavadoc](https://github.com/typesafehub/genjavadoc) sbt plugin, since the sources are written mostly in Scala.
+Akka-http generates JavaDoc-style API documentation using the [genjavadoc](https://github.com/typesafehub/genjavadoc) sbt plugin, since the sources are written mostly in Scala.
 
 Generating JavaDoc is not enabled by default, as it's not needed on day-to-day development as it's expected to just work.
 If you'd like to check if you links and formatting looks good in JavaDoc (and not only in ScalaDoc), you can generate it by running:
@@ -243,7 +240,7 @@ Example:
 
 ## Pull request validation workflow details
 
-Akka uses [Jenkins GitHub pull request builder plugin](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin)
+Akka-http uses [Jenkins GitHub pull request builder plugin](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin)
 that automatically merges the code, builds it, runs the tests and comments on the Pull Request in GitHub.
 
 Upon a submission of a Pull Request the GitHub pull request builder plugin will post a following comment:
@@ -255,10 +252,10 @@ From now on, whenever new commits are pushed to the Pull Request, a validation j
 
 A Pull Request validation job can be started manually by posting `PLS BUILD` comment on the Pull Request.
 
-In order to speed up PR validation times, the Akka build contains a special sbt task called `validatePullRequest`,
+In order to speed up PR validation times, the Akka-http build contains a special sbt task called `validatePullRequest`,
 which is smart enough to figure out which projects should be built if a PR only has changes in some parts of the project.
-For example, if your PR only touches `akka-persistence`, no `akka-remote` tests need to be run, however the task
-will validate all projects that depend on `akka-persistence` (including samples).
+For example, if your PR only touches `akka-http-testkit`, no `akka-parsing` tests need to be run, however the task
+will validate all projects that depend on `akka-http-testkit` (including samples).
 Also, tests tagged as `PerformanceTest` and the likes of it are excluded from PR validation.
 
 In order to force the `validatePullRequest` task to build the entire project, regardless of dependency analysis of a PRs
@@ -269,7 +266,7 @@ the validator to test all projects.
 
 ### Scala style 
 
-Akka uses [Scalariform](https://github.com/daniel-trinh/scalariform) to enforce some of the code style rules.
+Akka-http uses [Scalariform](https://github.com/daniel-trinh/scalariform) to enforce some of the code style rules.
 
 ### Java style
 
@@ -294,16 +291,6 @@ There is a number of ways timeouts can be defined in Akka tests. The following w
 Special care should be given `expectNoMsg` calls, which indeed will wait the entire timeout before continuing, therefore a shorter timeout should be used in those, for example `200` or `300.millis`.
 
 You can read up on remaining and friends in [TestKit.scala](https://github.com/akka/akka/blob/master/akka-testkit/src/main/scala/akka/testkit/TestKit.scala)
-
-## Contributing Modules
-
-For external contributions of entire features, the normal way is to establish it
-as a stand-alone feature first, to show that there is a need for the feature. The
-next step would be to add it to Akka as an "experimental feature" (in the
-akka-contrib subproject), then when the feature is hardened, well documented and
-tested it becomes an officially supported Akka feature.
-
-[List of experimental Akka features](http://doc.akka.io/docs/akka/current/experimental/index.html)
 
 # Supporting infrastructure
 


### PR DESCRIPTION
* Replace Akka project name with akka-http project name
* Update github URLS to right project
* Removed not present branches
* Removed Contrib module as it doesn't exist in akka-http
* Updated tags to more meaningful ones in akka-http